### PR TITLE
Introduce tagging to the trade feature

### DIFF
--- a/app/constants/key-codes.js
+++ b/app/constants/key-codes.js
@@ -1,0 +1,4 @@
+export default {
+  TAB: 9,
+  ENTER: 13
+};

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -142,6 +142,7 @@ export default {
       trade_page: {
         label_placeholder: "Label",
         notes_placeholder: "Notes",
+        tags_placeholder: "Tags",
         cancel: "Cancel",
         save: "Save",
         edit: "Edit",

--- a/app/models/trade.js
+++ b/app/models/trade.js
@@ -1,0 +1,40 @@
+// Vendors
+import EmberObject from '@ember/object';
+import {A} from '@ember/array';
+import moment from 'moment';
+
+export default EmberObject.extend({
+  id: null,
+  label: '',
+  notes: '',
+  slug: '',
+  tags: [],
+  updatedAt: null,
+
+  init() {
+    this.set('tags', A(this.tags));
+  },
+
+  updateProperties(properties) {
+    this.setProperties({
+      ...properties,
+      updatedAt: moment().toISOString()
+    });
+  },
+
+  clone() {
+    const tradeJson = this.asJson();
+
+    return this.constructor.create({
+      ...tradeJson,
+      tags: A(tradeJson.tags)
+    });
+  },
+
+  asJson() {
+    return {
+      ...this.getProperties('id', 'label', 'notes', 'slug', 'updatedAt'),
+      tags: this.tags.toArray()
+    };
+  }
+});

--- a/app/pods/components/pow-page/trade-page/component.js
+++ b/app/pods/components/pow-page/trade-page/component.js
@@ -3,11 +3,13 @@ import Component from '@ember/component';
 import {inject as service} from '@ember/service';
 import {computed} from '@ember/object';
 import {bool} from '@ember/object/computed';
-import moment from 'moment';
 
 // Constants
 import TRADE from 'poe-world/constants/trade';
 const TRADE_WEBSITE_OFFSET = 192;
+
+// Models
+import Trade from 'poe-world/models/trade';
 
 export default Component.extend({
   activeLeagueSetting: service('active-league/setting'),
@@ -65,16 +67,14 @@ export default Component.extend({
   },
 
   edit() {
-    this.set('stagedTrade', {
-      ...this.currentTrade
-    });
+    this.set('stagedTrade', this.currentTrade.clone());
   },
 
   save() {
-    this.set('stagedTrade.slug', this.currentTradeSlug);
-    this.set('stagedTrade.updatedAt', moment().toISOString());
-    if (!this.stagedTrade.label) this.set('stagedTrade.label', this.currentTradeSlug);
-
+    this.stagedTrade.updateProperties({
+      slug: this.currentTradeSlug,
+      label: this.stagedTrade.label || this.currentTradeSlug
+    });
     const savedTrade = this.tradePersister.persist(this.stagedTrade);
 
     this._refreshTrades();
@@ -94,19 +94,13 @@ export default Component.extend({
   create() {
     this.setProperties({
       currentTrade: null,
-      stagedTrade: {
-        label: '',
-        notes: '',
-        slug: '',
-        updatedAt: null
-      },
+      stagedTrade: Trade.create(),
       currentTradeSlug: ''
     });
   },
 
   updateTradeSlug() {
-    this.set('currentTrade.slug', this.currentTradeSlug);
-    this.set('currentTrade.updatedAt', moment().toISOString());
+    this.currentTrade.updateProperties({slug: this.currentTradeSlug});
     this.tradePersister.persist(this.currentTrade);
 
     this._refreshTrades();

--- a/app/pods/components/pow-page/trade-page/template.hbs
+++ b/app/pods/components/pow-page/trade-page/template.hbs
@@ -15,6 +15,22 @@
               </h2>
             {{/if}}
           </div>
+
+          <div class="pl-2">
+            {{#if isEditing}}
+              {{pow-tags-field
+                placeholder=(t "components.page.trade_page.tags_placeholder")
+                tags=stagedTrade.tags}}
+            {{else}}
+              <h4 class="mb-0 mt-2">
+                {{#each currentTrade.tags as |tag|}}
+                  <span class="badge badge-primary badge-pill text-capitalize px-2 py-1">
+                    {{tag}}
+                  </span>
+                {{/each}}
+              </h4>
+            {{/if}}
+          </div>
         </div>
 
         <div class="col-5">
@@ -133,8 +149,3 @@
     </ul>
   </div>
 </div>
-
-
-
-
-

--- a/app/pods/components/pow-page/trade-page/template.hbs
+++ b/app/pods/components/pow-page/trade-page/template.hbs
@@ -141,6 +141,14 @@
             {{trade.label}}
           </h5>
 
+          <div class="my-1">
+            {{#each trade.tags as |tag|}}
+              <span class="badge badge-primary badge-pill text-capitalize">
+                {{tag}}
+              </span>
+            {{/each}}
+          </div>
+
           <small>
             {{t "components.page.trade_page.updated_at" timeAgo=(moment-from-now trade.updatedAt)}}
           </small>

--- a/app/pods/components/pow-tags-field/component.js
+++ b/app/pods/components/pow-tags-field/component.js
@@ -1,0 +1,50 @@
+// Vendors
+import Component from '@ember/component';
+
+// Constants
+import KEY_CODES from 'poe-world/constants/key-codes';
+
+// Utilities
+import uuid from 'poe-world/utilities/uuid';
+
+export default Component.extend({
+  tagName: '',
+
+  label: null,
+  placeholder: null,
+  tags: [],
+
+  newTag: '',
+
+  willInsertElement() {
+    this.set('id', uuid());
+  },
+
+  remove(tagToRemove) {
+    this.tags.removeObject(tagToRemove);
+  },
+
+  newTagInputChange({target: {value}}) {
+    this.set('newTag', value);
+  },
+
+  newTagInputKeydown({keyCode}) {
+    if (![KEY_CODES.TAB, KEY_CODES.ENTER].includes(keyCode)) return true;
+
+    this._confirmNewTag();
+    return false;
+  },
+
+  newTagInputBlur() {
+    this._confirmNewTag();
+  },
+
+  _confirmNewTag() {
+    if (!this.newTag) return false;
+
+    this.tags.pushObject(this.newTag);
+    this.set('newTag', '');
+
+    return true;
+  }
+});

--- a/app/pods/components/pow-tags-field/styles.module.scss
+++ b/app/pods/components/pow-tags-field/styles.module.scss
@@ -1,0 +1,9 @@
+.input {
+  border: 0;
+  outline: none;
+  color: $gray-700;
+}
+
+.label-wrapper {
+  cursor: text;
+}

--- a/app/pods/components/pow-tags-field/template.hbs
+++ b/app/pods/components/pow-tags-field/template.hbs
@@ -1,0 +1,33 @@
+<div class="form-group">
+  {{#if label}}
+    <label for={{id}}>{{label}}</label>
+  {{/if}}
+
+  <label
+    for={{id}}
+    class="form-control py-0 d-flex align-items-center"
+    local-class="label-wrapper"
+  >
+    {{#each tags as |tag|}}
+      <button
+        type="button"
+        class="btn btn-primary btn-sm py-1 mr-1"
+        {{action remove tag}}
+      >
+        {{tag}}
+        {{fa-icon 'times' class="ml-1"}}
+      </button>
+    {{/each}}
+
+    <input
+      type="text"
+      id={{id}}
+      placeholder={{placeholder}}
+      value={{newTag}}
+      local-class="input"
+      oninput={{action newTagInputChange}}
+      onkeydown={{action newTagInputKeydown}}
+      onblur={{action newTagInputBlur}}
+    />
+  </label>
+</div>

--- a/app/services/trade/fetcher.js
+++ b/app/services/trade/fetcher.js
@@ -4,13 +4,18 @@ import Service, {inject as service} from '@ember/service';
 // Constants
 import STORAGE_KEYS from 'poe-world/constants/storage-keys';
 
+// Models
+import Trade from 'poe-world/models/trade';
+
 export default Service.extend({
   storage: service('storage'),
 
   fetchAll() {
-    return this.storage.getValue(STORAGE_KEYS.TRADE, {
+    const rawTrades = this.storage.getValue(STORAGE_KEYS.TRADE, {
       defaultValue: []
     });
+
+    return rawTrades.map((rawTrade) => Trade.create(rawTrade));
   }
 });
 

--- a/app/services/trade/persister.js
+++ b/app/services/trade/persister.js
@@ -9,20 +9,18 @@ import STORAGE_KEYS from 'poe-world/constants/storage-keys';
 
 export default Service.extend({
   storage: service('storage'),
+  tradeFetcher: service('trade/fetcher'),
 
   persist(trade) {
-    if (!trade.id) trade.id = uuid();
+    if (!trade.id) trade.set('id', uuid());
 
-    const trades = this.storage.getValue(STORAGE_KEYS.TRADE, {
-      defaultValue: []
-    });
-
+    const trades = this.tradeFetcher.fetchAll();
     const existingTrade = trades.find(({id}) => id === trade.id);
 
     if (existingTrade) {
-      Object.assign(existingTrade, trade);
+      Object.assign(existingTrade, trade.asJson());
     } else {
-      trades.unshift(trade);
+      trades.unshift(trade.asJson());
     }
 
     this.storage.setValue(STORAGE_KEYS.TRADE, trades);


### PR DESCRIPTION
Now trade queries can be tagged, it will be usefull to better group
queries by builds/league/etc once the filtering feature is on.